### PR TITLE
[everflow] calculate tx_pps & rx_pps in everflow policer test

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -19,6 +19,11 @@ pytestmark = [
 ]
 
 
+MEGABYTE = 1024 * 1024
+DEFAULT_PTF_SOCKET_RCV_SIZE = 10 * MEGABYTE
+DEFAULT_PTF_QLEN = 15000
+
+
 @pytest.fixture
 def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost):
     """
@@ -50,8 +55,8 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost):
                    platform_dir="ptftests",
                    testname="everflow_tb_test.EverflowTest" if not test_name else test_name,
                    params=params,
-                   socket_recv_size=10 * 1024 * 1024,
-                   qlen=15000,
+                   socket_recv_size=DEFAULT_PTF_SOCKET_RCV_SIZE,
+                   qlen=DEFAULT_PTF_QLEN,
                    log_file="/tmp/{}.{}.log".format(request.cls.__name__, request.function.__name__))
 
     return _partial_ptf_runner

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -50,7 +50,8 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost):
                    platform_dir="ptftests",
                    testname="everflow_tb_test.EverflowTest" if not test_name else test_name,
                    params=params,
-                   socket_recv_size=16384,
+                   socket_recv_size=10 * 1024 * 1024,
+                   qlen=15000,
                    log_file="/tmp/{}.{}.log".format(request.cls.__name__, request.function.__name__))
 
     return _partial_ptf_runner


### PR DESCRIPTION
This will also give visibility on tx/rx pps instead of asserting
on the number of packets.

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
