### PR TITLE
[everflow] stabilize policer test

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -8,6 +8,7 @@ Usage:          Examples of how to use:
 
 import sys
 import time
+import datetime
 import logging
 
 import ptf
@@ -104,6 +105,8 @@ class EverflowPolicerTest(BaseTest):
         logger.info(msg)
         msg = "cbs={}".format(self.cbs)
         logger.info(msg)
+        msg = "send_time={}".format(self.send_time)
+        logger.info(msg)
         msg = "tolerance={}".format(self.tolerance)
         logger.info(msg)
         msg = "min_range={}".format(self.min_rx_pps)
@@ -133,6 +136,7 @@ class EverflowPolicerTest(BaseTest):
         self.meter_type = self.test_params['meter_type']
         self.cir = int(self.test_params['cir'])
         self.cbs = int(self.test_params['cbs'])
+        self.send_time = int(self.test_params['send_time'])
         self.tolerance = int(self.test_params['tolerance'])
 
         assert_str = "meter_type({0}) not in {1}".format(self.meter_type, str(self.METER_TYPES))
@@ -246,32 +250,33 @@ class EverflowPolicerTest(BaseTest):
 
             return dataplane.match_exp_pkt(payload_mask, pkt)
 
+        # send some amount to absorb CBS capacity
+        testutils.send_packet(self, self.src_port, str(self.base_pkt), count=self.NUM_OF_TOTAL_PACKETS)
         self.dataplane.flush()
 
-        packet_flow_start_tstamp = time.time()
-        testutils.send_packet(self, self.src_port, str(self.base_pkt), count=self.NUM_OF_TOTAL_PACKETS)
-        packet_flow_end_tstamp = time.time()
-        packet_flow_duration = packet_flow_end_tstamp - packet_flow_start_tstamp
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=self.send_time)
+        tx_pkts = 0
+        while datetime.datetime.now() < end_time:
+            testutils.send_packet(self, self.src_port, str(self.base_pkt))
+            tx_pkts += 1
 
-        count = 0
-        for i in range(0,self.NUM_OF_TOTAL_PACKETS):
+        rx_pkts = 0
+        while True:
             (rcv_device, rcv_port, rcv_pkt, pkt_time) = testutils.dp_poll(self, timeout=0.1, exp_pkt=masked_exp_pkt)
             if rcv_pkt is not None and match_payload(rcv_pkt):
-                count += 1
-            elif count == 0:
-                assert_str = "The first mirrored packet is not recieved"
-                assert count > 0, assert_str # Fast failure without waiting for full iteration
+                rx_pkts += 1
             else:
                 break # No more packets available
 
-        tx_pps = self.NUM_OF_TOTAL_PACKETS / packet_flow_duration
-        rx_pps = count / packet_flow_duration
+        tx_pps = tx_pkts / self.send_time
+        rx_pps = rx_pkts / self.send_time
 
-        logger.info("Received {} mirrored packets after rate limiting".format(count))
+        logger.info("Sent {} packets".format(tx_pkts))
+        logger.info("Received {} mirrored packets after rate limiting".format(rx_pkts))
         logger.info("TX PPS {}".format(tx_pps))
         logger.info("RX PPS {}".format(rx_pps))
 
-        return count, tx_pps, rx_pps
+        return rx_pkts, tx_pps, rx_pps
 
 
     def runTest(self):
@@ -298,6 +303,11 @@ class EverflowPolicerTest(BaseTest):
         testutils.add_filter(self.greFilter)
 
         # Send traffic and verify the mirroed traffic is rate limited
-        count, tx_pps, rx_pps = self.checkMirroredFlow()
-        assert_str = "min({1}) <= count({0}) <= max({2})".format(count, self.min_rx_pps, self.max_rx_pps)
-        assert count >= self.min_rx_pps and rx_pps <= self.max_rx_pps, assert_str
+        rx_pkts, tx_pps, rx_pps = self.checkMirroredFlow()
+
+        assert_str = "Transmition rate is lower then policer rate limiting." \
+                     "Most probably slow testbed server issue: tx_pps({}) <= rx_pps_max({})".format(tx_pps, self.max_rx_pps)
+        assert tx_pps > self.max_rx_pps, assert_str
+
+        assert_str = "min({1}) <= pps({0}) <= max({2})".format(rx_pps, self.min_rx_pps, self.max_rx_pps)
+        assert rx_pps >= self.min_rx_pps and rx_pps <= self.max_rx_pps, assert_str

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -390,7 +390,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
             config_method,
             tbinfo
     ):
-        """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table."""
+        """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
+        This tests single rate three color policer mode and specifically checks CIR value
+        and switch behaviour under condition when CBS is assumed to be fully absorbed while
+        sending traffic over a period of time. Received packets are accumulated and actual
+        receive rate is calculated and compared with CIR value with tollerance range 10%.
+        """
         # Add explicit for regular packet so that it's dest port is different then mirror port
         # NOTE: This is important to add since for the Policer test case regular packets
         # and mirror packets can go to same interface, which causes tail drop of

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -20,7 +20,7 @@ pytestmark = [
 
 
 MEGABYTE = 1024 * 1024
-DEFAULT_PTF_SOCKET_RCV_SIZE = 10 * MEGABYTE
+DEFAULT_PTF_SOCKET_RCV_SIZE = 1 * MEGABYTE
 DEFAULT_PTF_QLEN = 15000
 
 
@@ -436,6 +436,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                meter_type="packets",
                                cir="100",
                                cbs="100",
+                               send_time="10",
                                tolerance="10")
         finally:
             # Clean up ACL rules and routes


### PR DESCRIPTION
Lower socket buffer size since it takes longer for ptf framework to send
a single packet (probably due to ptf recreates socket each time) and the
transmition rate drops to <100 pkts/s.

Another improvement is to continuously test policer during a period of
time rather then in a single packet batch. This reduces the probability
of getting out of tolerance range when ptf sends slower and packet
bucket has time to refill making the results much more reproducible
around the expected limited rate of 100 pkts/s. This approach is BTW
used in copp test.

Change-Id: I086b2e19d75327a4134f07a54a32db5329d670cd
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
